### PR TITLE
[FIX] remove faulty require in nginx-ingress state

### DIFF
--- a/nginx-ingress/nginx.sls
+++ b/nginx-ingress/nginx.sls
@@ -6,6 +6,5 @@ nginx-deploy:
   cmd.run:
     - name: "kubectl apply -f /var/lib/kubernetes-master/nginx.yaml"
     - require:
-      - kubernetes-master
       - file: /var/lib/kubernetes-master/nginx.yaml
 


### PR DESCRIPTION
When applying the state the require caused an error.

Do you know a solution for this other than removing the error?